### PR TITLE
Fix/dump

### DIFF
--- a/src/mipp.h
+++ b/src/mipp.h
@@ -986,6 +986,9 @@ void dump(const mipp::reg r, std::ostream &stream = std::cout, const uint32_t el
 		stream << (((int)l < (int)mipp::Lanes -1) ? " | " : "");
 	}
 	stream << "]";
+#ifdef MIPP_ALIGNED_LOADS
+	free(data);
+#endif
 }
 
 template <int N>
@@ -1013,6 +1016,9 @@ void dump(const mipp::msk m, std::ostream &stream = std::cout, const uint32_t el
 				stream << std::setw(elmtWidth) << (data[l * lane_size +i] ? 1 : 0) << ((i < lane_size -1) ? ", " : "");
 			stream << (((int)l < (int)mipp::Lanes -1) ? " | " : "");
 		}
+#ifdef MIPP_ALIGNED_LOADS
+		free(data);
+#endif
 	}
 	else if (bits == 16)
 	{
@@ -1030,6 +1036,9 @@ void dump(const mipp::msk m, std::ostream &stream = std::cout, const uint32_t el
 				stream << std::setw(elmtWidth) << (data[l * lane_size +i] ? 1 : 0) << ((i < lane_size -1) ? ", " : "");
 			stream << (((int)l < (int)mipp::Lanes -1) ? " | " : "");
 		}
+#ifdef MIPP_ALIGNED_LOADS
+		free(data);
+#endif
 	}
 	else if (bits == 32)
 	{
@@ -1047,6 +1056,9 @@ void dump(const mipp::msk m, std::ostream &stream = std::cout, const uint32_t el
 				stream << std::setw(elmtWidth) << (data[l * lane_size +i] ? 1 : 0) << ((i < lane_size -1) ? ", " : "");
 			stream << (((int)l < (int)mipp::Lanes -1) ? " | " : "");
 		}
+#ifdef MIPP_ALIGNED_LOADS
+		free(data);
+#endif
 	}
 	else if (bits == 64)
 	{
@@ -1064,6 +1076,9 @@ void dump(const mipp::msk m, std::ostream &stream = std::cout, const uint32_t el
 				stream << std::setw(elmtWidth) << (data[l * lane_size +i] ? 1 : 0) << ((i < lane_size -1) ? ", " : "");
 			stream << (((int)l < (int)mipp::Lanes -1) ? " | " : "");
 		}
+#ifdef MIPP_ALIGNED_LOADS
+		free(data);
+#endif
 	}
 
 	stream << "]";

--- a/src/mipp.h
+++ b/src/mipp.h
@@ -1000,7 +1000,11 @@ void dump(const mipp::msk m, std::ostream &stream = std::cout, const uint32_t el
 	if (bits == 8)
 	{
 		// const int8_t* data = (int8_t*)&r;
+#ifdef MIPP_ALIGNED_LOADS
+		int8_t* data = malloc<int8_t>(N);
+#else
 		int8_t data[N];
+#endif
 		store<int8_t>(data, r);
 
 		for (uint32_t l = 0; l < mipp::Lanes; l++)
@@ -1013,7 +1017,11 @@ void dump(const mipp::msk m, std::ostream &stream = std::cout, const uint32_t el
 	else if (bits == 16)
 	{
 		// const int16_t* data = (int16_t*)&r;
+#ifdef MIPP_ALIGNED_LOADS
+		int16_t* data = malloc<int8_t>(N);
+#else
 		int16_t data[N];
+#endif
 		store<int16_t>(data, r);
 
 		for (uint32_t l = 0; l < (int)mipp::Lanes; l++)
@@ -1026,7 +1034,11 @@ void dump(const mipp::msk m, std::ostream &stream = std::cout, const uint32_t el
 	else if (bits == 32)
 	{
 		// const int32_t* data = (int32_t*)&r;
+#ifdef MIPP_ALIGNED_LOADS
+		int32_t* data = malloc<int8_t>(N);
+#else
 		int32_t data[N];
+#endif
 		store<int32_t>(data, r);
 
 		for (uint32_t l = 0; l < (int)mipp::Lanes; l++)
@@ -1039,7 +1051,11 @@ void dump(const mipp::msk m, std::ostream &stream = std::cout, const uint32_t el
 	else if (bits == 64)
 	{
 		// const int64_t* data = (int64_t*)&r;
+#ifdef MIPP_ALIGNED_LOADS
+		int64_t* data = malloc<int8_t>(N);
+#else
 		int64_t data[N];
+#endif
 		store<int64_t>(data, r);
 
 		for (uint32_t l = 0; l < (int)mipp::Lanes; l++)

--- a/src/mipp.h
+++ b/src/mipp.h
@@ -971,7 +971,11 @@ void dump(const mipp::reg r, std::ostream &stream = std::cout, const uint32_t el
 	constexpr int32_t lane_size = (int32_t)(mipp::N<T>() / mipp::Lanes);
 
 //	const T* data = (T*)&r;
-	T data[mipp::nElReg<T>()];
+#ifdef MIPP_ALIGNED_LOADS
+   	T* data = malloc<T>(mipp::N<T>());
+#else
+   	T data[mipp::nElReg<T>()];
+#endif
 	store<T>(data, r);
 
 	stream << "[";


### PR DESCRIPTION
I've figured out that using aligned load/stores can cause segmentation faults in case of dumping a variable. 

```c++
#include <iostream>
#define MIPP_ALIGNED_LOADS
#include "src-mipp/mipp.h"
int main() {
   mipp::Reg<float_t > a(2);
   std::cout << a << std::endl;
   return 0;
}
```
![grafik](https://user-images.githubusercontent.com/32478819/68082046-efa85480-fe17-11e9-9ff0-9e421a698fbc.png)
