### PR TITLE
Improve interleave and deinterleave (#17)

### DIFF
--- a/src/mipp_impl_AVX512.hxx
+++ b/src/mipp_impl_AVX512.hxx
@@ -495,19 +495,19 @@
 		return (__m512i)mipp::load<int16_t>((int16_t*)data);
 	}
 
-	// static __m512i _mm512_setr_epi16 (short  e0, short  e1, short  e2, short  e3, short  e4, short  e5, short  e6, short  e7,
-	//                                   short  e8, short  e9, short e10, short e11, short e12, short e13, short e14, short e15,
-	//                                   short e16, short e17, short e18, short e19, short e20, short e21, short e22, short e23,
-	//                                   short e24, short e25, short e26, short e27, short e28, short e29, short e30, short e31)
-	// {
-	// 	short data[32] = {e0,   e1,  e2,  e3,  e4,  e5,  e6,  e7,
-	// 	                  e8,   e9, e10, e11, e12, e13, e14, e15,
-	// 	                  e16, e17, e18, e19, e20, e21, e22, e23,
-	// 	                  e24, e25, e26, e27, e28, e29, e30, e31};
+	static __m512i _mm512_setr_epi16 (short  e0, short  e1, short  e2, short  e3, short  e4, short  e5, short  e6, short e7,
+	                                  short  e8, short  e9, short e10, short e11, short e12, short e13, short e14, short e15,
+	                                  short e16, short e17, short e18, short e19, short e20, short e21, short e22, short e23,
+	                                  short e24, short e25, short e26, short e27, short e28, short e29, short e30, short e31)
+	{
+		short data[32] = {e0,   e1,  e2,  e3,  e4,  e5,  e6,  e7,
+		                  e8,   e9, e10, e11, e12, e13, e14, e15,
+		                  e16, e17, e18, e19, e20, e21, e22, e23,
+		                  e24, e25, e26, e27, e28, e29, e30, e31};
 
-	// 	return (__m512i)mipp::load<int16_t>((int16_t*)data);
-	// }
-
+		return (__m512i)mipp::load<int16_t>((int16_t*)data);
+	}
+	
 	static __m512i _mm512_set_epi8 (char e63, char e62, char e61, char e60, char e59, char e58, char e57, char e56,
 	                                char e55, char e54, char e53, char e52, char e51, char e50, char e49, char e48,
 	                                char e47, char e46, char e45, char e44, char e43, char e42, char e41, char e40,
@@ -1434,84 +1434,51 @@
 #if defined(__AVX512F__)
 	template <>
 	inline regx2 interleave<double>(const reg v1, const reg v2) {
-		auto lo4 = mipp::interleavelo4<double>(v1, v2);
-		auto hi4 = mipp::interleavehi4<double>(v1, v2);
-		auto idxlo = _mm512_set_epi64(8|3,8|2,
-		                                3,  2,
-		                              8|1,8|0,
-		                                1,  0);
-		auto idxhi = _mm512_set_epi64(8|7,8|6,
-		                                7,  6,
-		                              8|5,8|4,
-		                                5,  4);
-		return {{_mm512_castpd_ps(_mm512_permutex2var_pd(_mm512_castps_pd(lo4), idxlo, _mm512_castps_pd(hi4))),
-		         _mm512_castpd_ps(_mm512_permutex2var_pd(_mm512_castps_pd(lo4), idxhi, _mm512_castps_pd(hi4)))}};
+		__m512i idx = _mm512_setr_epi64(0, 8, 1, 9, 2, 10, 3, 11);
+		auto hi = _mm512_permutex2var_pd(_mm512_castps_pd(v1), idx, _mm512_castps_pd(v2));
+		idx = _mm512_setr_epi64(4, 12, 5, 13, 6, 14, 7, 15);
+		auto lo = _mm512_permutex2var_pd(_mm512_castps_pd(v1), idx, _mm512_castps_pd(v2));
+		return {{_mm512_castpd_ps(hi), _mm512_castpd_ps(lo)}};
 	}
 
 	template <>
 	inline regx2 interleave<float>(const reg v1, const reg v2) {
-		auto lo4 = mipp::interleavelo4<float>(v1, v2);
-		auto hi4 = mipp::interleavehi4<float>(v1, v2);
-		auto idxlo = _mm512_set_epi64(8|3,8|2,
-		                                3,  2,
-		                              8|1,8|0,
-		                                1,  0);
-		auto idxhi = _mm512_set_epi64(8|7,8|6,
-		                                7,  6,
-		                              8|5,8|4,
-		                                5,  4);
-		return {{_mm512_castpd_ps(_mm512_permutex2var_pd(_mm512_castps_pd(lo4), idxlo, _mm512_castps_pd(hi4))),
-		         _mm512_castpd_ps(_mm512_permutex2var_pd(_mm512_castps_pd(lo4), idxhi, _mm512_castps_pd(hi4)))}};
+		__m512i idx = _mm512_setr_epi32(0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23);
+		auto hi = _mm512_permutex2var_ps(v1, idx, v2);
+		idx = _mm512_setr_epi32(8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31);
+		auto lo = _mm512_permutex2var_ps(v1, idx, v2);
+		return {{hi, lo}};
 	}
 
 	template <>
 	inline regx2 interleave<int64_t>(const reg v1, const reg v2) {
-		auto lo4 = mipp::interleavelo4<int64_t>(v1, v2);
-		auto hi4 = mipp::interleavehi4<int64_t>(v1, v2);
-		auto idxlo = _mm512_set_epi64(8|3,8|2,
-		                                3,  2,
-		                              8|1,8|0,
-		                                1,  0);
-		auto idxhi = _mm512_set_epi64(8|7,8|6,
-		                                7,  6,
-		                              8|5,8|4,
-		                                5,  4);
-		return {{_mm512_castpd_ps(_mm512_permutex2var_pd(_mm512_castps_pd(lo4), idxlo, _mm512_castps_pd(hi4))),
-		         _mm512_castpd_ps(_mm512_permutex2var_pd(_mm512_castps_pd(lo4), idxhi, _mm512_castps_pd(hi4)))}};
+		__m512i idx = _mm512_setr_epi64(0, 8, 1, 9, 2, 10, 3, 11);
+		auto hi = _mm512_permutex2var_epi64(_mm512_castps_si512(v1), idx, _mm512_castps_si512(v2));
+		idx = _mm512_setr_epi64(4, 12, 5, 13, 6, 14, 7, 15);
+		auto lo = _mm512_permutex2var_epi64(_mm512_castps_si512(v1), idx, _mm512_castps_si512(v2));
+		return {{_mm512_castsi512_ps(hi), _mm512_castsi512_ps(lo)}};
 	}
 
 	template <>
 	inline regx2 interleave<int32_t>(const reg v1, const reg v2) {
-		auto lo4 = mipp::interleavelo4<int32_t>(v1, v2);
-		auto hi4 = mipp::interleavehi4<int32_t>(v1, v2);
-		auto idxlo = _mm512_set_epi64(8|3,8|2,
-		                                3,  2,
-		                              8|1,8|0,
-		                                1,  0);
-		auto idxhi = _mm512_set_epi64(8|7,8|6,
-		                                7,  6,
-		                              8|5,8|4,
-		                                5,  4);
-		return {{_mm512_castpd_ps(_mm512_permutex2var_pd(_mm512_castps_pd(lo4), idxlo, _mm512_castps_pd(hi4))),
-		         _mm512_castpd_ps(_mm512_permutex2var_pd(_mm512_castps_pd(lo4), idxhi, _mm512_castps_pd(hi4)))}};
+		__m512i idx = _mm512_setr_epi32(0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23);
+		auto hi = _mm512_permutex2var_epi32(_mm512_castps_si512(v1), idx, _mm512_castps_si512(v2));
+		idx = _mm512_setr_epi32(8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31);
+		auto lo = _mm512_permutex2var_epi32(_mm512_castps_si512(v1), idx, _mm512_castps_si512(v2));
+		return {{_mm512_castsi512_ps(hi), _mm512_castsi512_ps(lo)}};
 	}
 #endif
 
 #if defined(__AVX512BW__)
 	template <>
 	inline regx2 interleave<int16_t>(const reg v1, const reg v2) {
-		auto lo4 = mipp::interleavelo4<int16_t>(v1, v2);
-		auto hi4 = mipp::interleavehi4<int16_t>(v1, v2);
-		auto idxlo = _mm512_set_epi64(8|3,8|2,
-		                                3,  2,
-		                              8|1,8|0,
-		                                1,  0);
-		auto idxhi = _mm512_set_epi64(8|7,8|6,
-		                                7,  6,
-		                              8|5,8|4,
-		                                5,  4);
-		return {{_mm512_castpd_ps(_mm512_permutex2var_pd(_mm512_castps_pd(lo4), idxlo, _mm512_castps_pd(hi4))),
-		         _mm512_castpd_ps(_mm512_permutex2var_pd(_mm512_castps_pd(lo4), idxhi, _mm512_castps_pd(hi4)))}};
+		__m512i idx = _mm512_setr_epi16(0, 32, 1, 33,  2, 34,  3, 35,  4, 36,  5, 37,  6, 38,  7, 39, 
+										8, 40, 9, 41, 10, 42, 11, 43, 12, 44, 13, 45, 14, 46, 15, 47);
+		auto hi = _mm512_permutex2var_epi16(_mm512_castps_si512(v1), idx, _mm512_castps_si512(v2));
+		idx = _mm512_setr_epi16(16, 48, 17, 49, 18, 50, 19, 51, 20, 52, 21, 53, 22, 54, 23, 55, 
+								24, 56, 25, 57, 26, 58, 27, 59, 28, 60, 29, 61, 30, 62, 31, 63);
+		auto lo = _mm512_permutex2var_epi16(_mm512_castps_si512(v1), idx, _mm512_castps_si512(v2));
+		return {{_mm512_castsi512_ps(hi), _mm512_castsi512_ps(lo)}};
 	}
 
 	template <>
@@ -1530,127 +1497,76 @@
 		         _mm512_castpd_ps(_mm512_permutex2var_pd(_mm512_castps_pd(lo4), idxhi, _mm512_castps_pd(hi4)))}};
 	}
 #endif
-
+	//#if defined(__AVX512VMBI__)
+	//	template <>
+	//	inline regx2 interleave<int8_t>(const reg v1, const reg v2) {
+	//		__m512i idx = _mm512_setr_epi8( 0, 64,  1, 65,  2, 66,  3, 67,  4, 68,  5, 69,  6, 70,  7, 71,
+	//										8, 72,  9, 73, 10, 74, 11, 75, 12, 76, 13, 77, 14, 78, 15, 79,
+	//									   16, 80, 17, 81, 18, 82, 19, 83, 20, 84, 21, 85, 22, 86, 23, 87,
+	//									   24, 88, 25, 89, 26, 90, 27, 91, 28, 92, 29, 93, 30, 94, 31, 95);
+	//		auto hi = _mm512_permutex2var_epi8(_mm512_castps_si512(v1), idx, _mm512_castps_si512(v2));
+	//		idx = _mm512_setr_epi8( 32,  96, 33,  97, 34,  98, 35,  99, 36, 100, 37, 101, 38, 102, 39, 103,
+	//								40, 104, 41, 105, 42, 106, 43, 107, 44, 108, 45, 109, 46, 110, 47, 111,
+	//								48, 112, 49, 113, 50, 114, 51, 115, 52, 116, 53, 117, 54, 118, 55, 119,
+	//								56, 120, 57, 121, 58, 122, 59, 123, 60, 124, 61, 125, 62, 126, 63, 127);
+	//		
+	//		auto lo = _mm512_permutex2var_epi8(_mm512_castps_si512(v1), idx, _mm512_castps_si512(v2));
+	//		return {{_mm512_castsi512_ps(hi), _mm512_castsi512_ps(lo)}};
+	//	}
+	//#endif
 	// --------------------------------------------------------------------------------------------------- deinterleave
 	template <>
 	inline regx2 deinterleave<double>(const reg v0, const reg v1)
 	{
-		// const uint32_t cmask[8] = {0, 2, 4, 6, 1, 3, 5, 7};
-		// auto cm = mipp::cmask<double>(cmask);
-
-		auto cm = _mm512_castsi512_ps(_mm512_setr_epi32(0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15));
-
-		auto v0s = mipp::shuff<double>(v0, cm);
-		auto v1s = mipp::shuff<double>(v1, cm);
-
-		auto v0l = mipp::low<double>(v0s);
-		auto v1l = mipp::low<double>(v1s);
-
-		auto v0h = mipp::high<double>(v0s);
-		auto v1h = mipp::high<double>(v1s);
-
-		auto v_re = mipp::combine<double>(v0l, v1l);
-		auto v_im = mipp::combine<double>(v0h, v1h);
-
-		return {{v_re, v_im}};
+		__m512i realIndicies = _mm512_setr_epi64(0, 2, 4, 6, 8, 10, 12, 14);
+		__m512i imagIndicies = _mm512_setr_epi64(1, 3, 5, 7, 9, 11, 13, 15);
+		auto v_re = _mm512_permutex2var_pd(_mm512_castps_pd(v0), realIndicies, _mm512_castps_pd(v1));
+		auto v_im = _mm512_permutex2var_pd(_mm512_castps_pd(v0), imagIndicies, _mm512_castps_pd(v1));
+		return {{_mm512_castpd_ps(v_re), _mm512_castpd_ps(v_im)}};
 	}
 
 	template <>
 	inline regx2 deinterleave<int64_t>(const reg v0, const reg v1)
 	{
-		// const uint32_t cmask[8] = {0, 2, 4, 6, 1, 3, 5, 7};
-		// auto cm = mipp::cmask<int64_t>(cmask);
-
-		auto cm = _mm512_castsi512_ps(_mm512_setr_epi32(0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15));
-
-		auto v0s = mipp::shuff<int64_t>(v0, cm);
-		auto v1s = mipp::shuff<int64_t>(v1, cm);
-
-		auto v0l = mipp::low<int64_t>(v0s);
-		auto v1l = mipp::low<int64_t>(v1s);
-
-		auto v0h = mipp::high<int64_t>(v0s);
-		auto v1h = mipp::high<int64_t>(v1s);
-
-		auto v_re = mipp::combine<int64_t>(v0l, v1l);
-		auto v_im = mipp::combine<int64_t>(v0h, v1h);
-
-		return {{v_re, v_im}};
+		__m512i realIndicies = _mm512_setr_epi64(0, 2, 4, 6, 8, 10, 12, 14);
+		__m512i imagIndicies = _mm512_setr_epi64(1, 3, 5, 7, 9, 11, 13, 15);
+		auto v_re = _mm512_permutex2var_epi64(_mm512_castps_si512(v0), realIndicies, _mm512_castps_si512(v1));
+		auto v_im = _mm512_permutex2var_epi64(_mm512_castps_si512(v0), imagIndicies, _mm512_castps_si512(v1));
+		return {{_mm512_castsi512_ps(v_re), _mm512_castsi512_ps(v_im)}};
 	}
 
 	template <>
 	inline regx2 deinterleave<float>(const reg v0, const reg v1)
 	{
-		// const uint32_t cmask[16] = {0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15};
-		// auto cm = mipp::cmask<float>(cmask);
-
-		auto cm = _mm512_castsi512_ps(_mm512_setr_epi32(0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15));
-
-		auto v0s = mipp::shuff<float>(v0, cm);
-		auto v1s = mipp::shuff<float>(v1, cm);
-
-		auto v0l = mipp::low<float>(v0s);
-		auto v1l = mipp::low<float>(v1s);
-
-		auto v0h = mipp::high<float>(v0s);
-		auto v1h = mipp::high<float>(v1s);
-
-		auto v_re = mipp::combine<float>(v0l, v1l);
-		auto v_im = mipp::combine<float>(v0h, v1h);
-
+		__m512i realIndicies = _mm512_setr_epi32(0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30);
+		__m512i imagIndicies = _mm512_setr_epi32(1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31);
+		auto v_re = _mm512_permutex2var_ps(v0, realIndicies, v1);
+		auto v_im = _mm512_permutex2var_ps(v0, imagIndicies, v1);
 		return {{v_re, v_im}};
 	}
 
 	template <>
 	inline regx2 deinterleave<int32_t>(const reg v0, const reg v1)
 	{
-		// const uint32_t cmask[16] = {0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15};
-		// auto cm = mipp::cmask<int32_t>(cmask);
-
-		auto cm = _mm512_castsi512_ps(_mm512_setr_epi32(0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15));
-
-		auto v0s = mipp::shuff<int32_t>(v0, cm);
-		auto v1s = mipp::shuff<int32_t>(v1, cm);
-
-		auto v0l = mipp::low<int32_t>(v0s);
-		auto v1l = mipp::low<int32_t>(v1s);
-
-		auto v0h = mipp::high<int32_t>(v0s);
-		auto v1h = mipp::high<int32_t>(v1s);
-
-		auto v_re = mipp::combine<int32_t>(v0l, v1l);
-		auto v_im = mipp::combine<int32_t>(v0h, v1h);
-
-		return {{v_re, v_im}};
+		__m512i realIndicies = _mm512_setr_epi32(0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30);
+		__m512i imagIndicies = _mm512_setr_epi32(1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31);
+		auto v_re = _mm512_permutex2var_epi32(_mm512_castps_si512(v0), realIndicies, _mm512_castps_si512(v1));
+		auto v_im = _mm512_permutex2var_epi32(_mm512_castps_si512(v0), imagIndicies, _mm512_castps_si512(v1));
+		return {{_mm512_castsi512_ps(v_re), _mm512_castsi512_ps(v_im)}};
 	}
 
 #ifdef __AVX512BW__
 	template <>
 	inline regx2 deinterleave<int16_t>(const reg v0, const reg v1)
 	{
-		// const uint32_t cmask[32] = {0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30,
-		//                             1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31};
-		// auto cm = mipp::cmask<int16_t>(cmask);
-
-		// auto cm = _mm512_castsi512_ps(_mm512_setr_epi16(0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30,
-		//                                                 1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31));
-
-		auto cm = _mm512_castsi512_ps(_mm512_set_epi16(31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11, 9, 7, 5, 3, 1,
-		                                               30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 0));
-
-		auto v0s = mipp::shuff<int16_t>(v0, cm);
-		auto v1s = mipp::shuff<int16_t>(v1, cm);
-
-		auto v0l = mipp::low<int16_t>(v0s);
-		auto v1l = mipp::low<int16_t>(v1s);
-
-		auto v0h = mipp::high<int16_t>(v0s);
-		auto v1h = mipp::high<int16_t>(v1s);
-
-		auto v_re = mipp::combine<int16_t>(v0l, v1l);
-		auto v_im = mipp::combine<int16_t>(v0h, v1h);
-
-		return {{v_re, v_im}};
+		__m512i realIndicies = _mm512_setr_epi16( 0,  2,  4,  6,  8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30,
+												 32, 34, 36, 38, 40, 42, 44, 46, 48, 50, 52, 54, 56, 58, 60, 62);
+		__m512i imagIndicies = _mm512_setr_epi16( 1,  3,  5,  7,  9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31, 
+												 33, 35, 37, 39, 41, 43, 45, 47, 49, 51, 53, 55, 57, 59, 61, 63);
+		auto v_re = _mm512_permutex2var_epi16(_mm512_castps_si512(v0), realIndicies, _mm512_castps_si512(v1));
+		auto v_im = _mm512_permutex2var_epi16(_mm512_castps_si512(v0), imagIndicies, _mm512_castps_si512(v1));
+		return {{_mm512_castsi512_ps(v_re), _mm512_castsi512_ps(v_im)}};
+		
 	}
 
 	template <>
@@ -1686,8 +1602,26 @@
 
 		return {{v_re, v_im}};
 	}
+	
+	
 #endif
-
+	//#if defined(__AVX512VMBI__)
+	// template <>
+	// inline regx2 deinterleave<int8_t>(const reg v0, const reg v1)
+	// {
+	// 	__m512i realIndicies = _mm512_setr_epi8(  0,  2,   4,   6,   8,  10,  12,  14,  16,  18,  20,  22,  24,  26,  28,  30,
+	// 											 32, 34,  36,  38,  40,  42,  44,  46,  48,  50,  52,  54,  56,  58,  60,  62,
+	// 											 64, 66,  68,  70,  72,  74,  76,  78,  80,  82,  84,  86,  88,  90,  92,  94,
+	// 											 96, 98, 100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124, 126);
+	// 	__m512i imagIndicies = _mm512_setr_epi8( 1,  3,  5,    7,   9,  11,  13,  15,  17,  19,  21,  23,  25,  27,  29,  31, 
+	// 											33, 35, 37,   39,  41,  43,  45,  47,  49,  51,  53,  55,  57,  59,  61,  63,
+	// 											65, 67, 69,   71,  73,  75,  77,  79,  81,  83,  85,  87,  89,  91,  93,  95,
+	// 											97, 99, 101, 103, 105, 107, 109, 111, 113, 115, 117, 119, 121, 123, 125, 127);
+	// 	auto v_re = _mm512_permutex2var_epi8(_mm512_castps_si512(v0), realIndicies, _mm512_castps_si512(v1));
+	// 	auto v_im = _mm512_permutex2var_epi8(_mm512_castps_si512(v0), imagIndicies, _mm512_castps_si512(v1));
+	// 	return {{_mm512_castsi512_ps(v_re), _mm512_castsi512_ps(v_im)}};
+	// }
+	//#endif
 	// --------------------------------------------------------------------------------------------------- interleavelo
 #if defined(__AVX512F__)
 	template <>


### PR DESCRIPTION
Fixes #17 
int8_t methods would require the `_mm512_permutex2var_epi8` method - this is only available on machines with AVX512VMBI