### PR TITLE
Fix __cplusplus macro to detect C++ version

### DIFF
--- a/src/mipp.h
+++ b/src/mipp.h
@@ -544,7 +544,7 @@ static inline void errorMessage(std::string instr)
 	type_names[typeid(double)  ] = "double";
 
 	std::string message;
-#if cplusplus >= 201703L
+#if __cplusplus >= 201703L
 	if constexpr (RegisterSizeBit == 0)
 #else
 	if (RegisterSizeBit == 0)
@@ -563,7 +563,7 @@ template <int N>
 static inline void errorMessage(std::string instr)
 {
 	std::string message;
-#if cplusplus >= 201703L
+#if __cplusplus >= 201703L
 	if constexpr (RegisterSizeBit == 0)
 #else
 	if (RegisterSizeBit == 0)


### PR DESCRIPTION
https://github.com/aff3ct/MIPP/blob/f45fe6d175d0f77207d0bba49ebcc7670fdc27f0/src/mipp.h#L547
and
https://github.com/aff3ct/MIPP/blob/f45fe6d175d0f77207d0bba49ebcc7670fdc27f0/src/mipp.h#L566

do not use the right macro to detect the current C++ version. Thus, the related optimization was never enabled.