### PR TITLE
Fix compile error with MSVC for Arm Neon target

### DIFF
--- a/src/mipp.h
+++ b/src/mipp.h
@@ -689,7 +689,9 @@ template <typename T> inline reg   msb          (const reg)                     
 template <typename T> inline reg   msb          (const reg, const reg)            { errorMessage<T>("msb");           exit(-1); }
 template <typename T> inline msk   sign         (const reg)                       { errorMessage<T>("sign");          exit(-1); }
 template <typename T> inline reg   neg          (const reg, const reg)            { errorMessage<T>("neg");           exit(-1); }
+#if !(defined(_MSC_VER) && defined(_M_ARM))  //Avoid compiling error with MSVC for ARM
 template <typename T> inline reg   neg          (const reg, const msk)            { errorMessage<T>("neg");           exit(-1); }
+#endif
 template <typename T> inline reg   abs          (const reg)                       { errorMessage<T>("abs");           exit(-1); }
 template <typename T> inline reg   sqrt         (const reg)                       { errorMessage<T>("sqrt");          exit(-1); }
 template <typename T> inline reg   rsqrt        (const reg)                       { errorMessage<T>("rsqrt");         exit(-1); }
@@ -763,8 +765,9 @@ inline regx2 deinterleave(const regx2 v)
 // ------------------------------------------------------------------------------------------------------------ aliases
 // --------------------------------------------------------------------------------------------------------------------
 template <typename T> inline reg copysign(const reg r1, const reg r2) { return neg<T>(r1, r2); }
+#if !(defined(_MSC_VER) && defined(_M_ARM))  //Avoid compiling error with MSVC for ARM
 template <typename T> inline reg copysign(const reg r1, const msk r2) { return neg<T>(r1, r2); }
-
+#endif
 // --------------------------------------------------------------------------------- hyperbolic trigonometric functions
 // --------------------------------------------------------------------------------------------------------------------
 template <typename T>

--- a/src/mipp_impl_NEON.hxx
+++ b/src/mipp_impl_NEON.hxx
@@ -2251,10 +2251,12 @@
 		return xorb<float>(v1, msb<float>(v2));
 	}
 
+#if !(defined(_MSC_VER) && defined(_M_ARM))  //Avoid compiling error with MSVC for ARM
 	template <>
 	inline reg neg<float>(const reg v1, const msk v2) {
 		return neg<float>(v1, toreg<4>(v2));
 	}
+#endif
 
 #ifdef __aarch64__
 	template <>
@@ -2285,10 +2287,12 @@
 		return res;
 	}
 
+#if !(defined(_MSC_VER) && defined(_M_ARM))  //Avoid compiling error with MSVC for ARM
 	template <>
 	inline reg neg<int32_t>(const reg v1, const msk v2) {
 		return neg<int32_t>(v1, toreg<4>(v2));
 	}
+#endif
 
 	template <>
 	inline reg neg<int16_t>(const reg v1, const reg v2) {
@@ -2301,10 +2305,12 @@
 		return res;
 	}
 
+#if !(defined(_MSC_VER) && defined(_M_ARM))  //Avoid compiling error with MSVC for ARM
 	template <>
 	inline reg neg<int16_t>(const reg v1, const msk v2) {
 		return neg<int16_t>(v1, toreg<8>(v2));
 	}
+#endif
 
 	template <>
 	inline reg neg<int8_t>(const reg v1, const reg v2) {
@@ -2317,10 +2323,12 @@
 		return res;
 	}
 
+#if !(defined(_MSC_VER) && defined(_M_ARM))  //Avoid compiling error with MSVC for ARM
 	template <>
 	inline reg neg<int8_t>(const reg v1, const msk v2) {
 		return neg<int8_t>(v1, toreg<16>(v2));
 	}
+#endif
 
 	// ------------------------------------------------------------------------------------------------------------ abs
 #ifdef __aarch64__


### PR DESCRIPTION
When compiling with MSVC NEON intrinsics, reg(=float32x4_t) and msk(=uintt32x4_t) are considered as the same type (__n128), causing some of the function overloading to appear like duplication. The current change is aimed to fix this issue.