### PR TITLE
Add r(and l)shiftr functions for SSE2

### DIFF
--- a/src/mipp_impl_SSE.hxx
+++ b/src/mipp_impl_SSE.hxx
@@ -902,7 +902,51 @@
 #endif
 
 	// -------------------------------------------------------------------------------------------------------- lshiftr
+#ifdef __SSE2__
+	template <>
+	inline reg lshiftr<int64_t>(const reg v1, const reg v2) {
+		int64_t t1[2], t2[2];
+		mipp::storeu<int64_t>(t1, v1);
+		mipp::storeu<int64_t>(t2, v2);
+		for (int i = 0; i < 2; i++){
+			t1[i] <<= t2[i];			
+		}
+		return mipp::loadu<int64_t>(t1);
+	}
 
+	template <>
+	inline reg lshiftr<int32_t>(const reg v1, const reg v2) {
+		int32_t t1[4], t2[4];
+		mipp::storeu<int32_t>(t1, v1);
+		mipp::storeu<int32_t>(t2, v2);
+		for (int i = 0; i < 4; i++){
+			t1[i] <<= t2[i];			
+		}
+		return mipp::loadu<int32_t>(t1);
+	}
+
+	template <>
+	inline reg lshiftr<int16_t>(const reg v1, const reg v2) {
+		int16_t t1[8], t2[8];
+		mipp::storeu<int16_t>(t1, v1);
+		mipp::storeu<int16_t>(t2, v2);
+		for (int i = 0; i < 8; i++){
+			t1[i] <<= t2[i];			
+		}
+		return mipp::loadu<int16_t>(t1);
+	}
+
+	template <>
+	inline reg lshiftr<int8_t>(const reg v1, const reg v2) {
+		int8_t t1[16], t2[16];
+		mipp::storeu<int8_t>(t1, v1);
+		mipp::storeu<int8_t>(t2, v2);
+		for (int i = 0; i < 16; i++){
+			t1[i] <<= t2[i];			
+		}
+		return mipp::loadu<int8_t>(t1);
+	}
+#endif
 	// -------------------------------------------------------------------------------------------------- lshift (mask)
 #ifdef __SSE2__
 #if !defined(__clang__) && !defined(_MSC_VER) && !defined(__GNUC__)
@@ -970,7 +1014,51 @@
 #endif
 
 	// -------------------------------------------------------------------------------------------------------- rshiftr
+#ifdef __SSE2__
+	template <>
+	inline reg rshiftr<int64_t>(const reg v1, const reg v2) {
+		int64_t t1[2], t2[2];
+		mipp::storeu<int64_t>(t1, v1);
+		mipp::storeu<int64_t>(t2, v2);
+		for (int i = 0; i < 2; i++){
+			t1[i] >>= t2[i];			
+		}
+		return mipp::loadu<int64_t>(t1);
+	}
 
+	template <>
+	inline reg rshiftr<int32_t>(const reg v1, const reg v2) {
+		int32_t t1[4], t2[4];
+		mipp::storeu<int32_t>(t1, v1);
+		mipp::storeu<int32_t>(t2, v2);
+		for (int i = 0; i < 4; i++){
+			t1[i] >>= t2[i];			
+		}
+		return mipp::loadu<int32_t>(t1);
+	}
+
+	template <>
+	inline reg rshiftr<int16_t>(const reg v1, const reg v2) {
+		int16_t t1[8], t2[8];
+		mipp::storeu<int16_t>(t1, v1);
+		mipp::storeu<int16_t>(t2, v2);
+		for (int i = 0; i < 8; i++){
+			t1[i] >>= t2[i];			
+		}
+		return mipp::loadu<int16_t>(t1);
+	}
+	
+	template <>
+	inline reg rshiftr<int8_t>(const reg v1, const reg v2) {
+		int8_t t1[16], t2[16];
+		mipp::storeu<int8_t>(t1, v1);
+		mipp::storeu<int8_t>(t2, v2);
+		for (int i = 0; i < 16; i++){
+			t1[i] >>= t2[i];			
+		}
+		return mipp::loadu<int8_t>(t1);
+	}
+#endif
 	// -------------------------------------------------------------------------------------------------- rshift (mask)
 #ifdef __SSE2__
 #if !defined(__clang__) && !defined(_MSC_VER) && !defined(__GNUC__)

--- a/src/mipp_impl_SSE.hxx
+++ b/src/mipp_impl_SSE.hxx
@@ -902,7 +902,6 @@
 #endif
 
 	// -------------------------------------------------------------------------------------------------------- lshiftr
-#ifdef __SSE2__
 	template <>
 	inline reg lshiftr<int64_t>(const reg v1, const reg v2) {
 		int64_t t1[2], t2[2];
@@ -946,7 +945,6 @@
 		}
 		return mipp::loadu<int8_t>(t1);
 	}
-#endif
 	// -------------------------------------------------------------------------------------------------- lshift (mask)
 #ifdef __SSE2__
 #if !defined(__clang__) && !defined(_MSC_VER) && !defined(__GNUC__)
@@ -1014,7 +1012,6 @@
 #endif
 
 	// -------------------------------------------------------------------------------------------------------- rshiftr
-#ifdef __SSE2__
 	template <>
 	inline reg rshiftr<int64_t>(const reg v1, const reg v2) {
 		int64_t t1[2], t2[2];
@@ -1058,7 +1055,6 @@
 		}
 		return mipp::loadu<int8_t>(t1);
 	}
-#endif
 	// -------------------------------------------------------------------------------------------------- rshift (mask)
 #ifdef __SSE2__
 #if !defined(__clang__) && !defined(_MSC_VER) && !defined(__GNUC__)

--- a/tests/src/bitwise_operations/lshiftr.cpp
+++ b/tests/src/bitwise_operations/lshiftr.cpp
@@ -30,7 +30,6 @@ void test_reg_lshiftr()
 }
 
 #ifndef MIPP_NO
-#if !defined(MIPP_SSE1)
 TEST_CASE("Binary left shift (register) - mipp::reg", "[mipp::lshiftr]")
 {
 #if !defined(MIPP_AVX) || (defined(MIPP_AVX) && MIPP_INSTR_VERSION >= 2)
@@ -48,7 +47,6 @@ TEST_CASE("Binary left shift (register) - mipp::reg", "[mipp::lshiftr]")
 #endif
 #endif
 }
-#endif
 #endif
 
 template <typename T>
@@ -74,7 +72,6 @@ void test_Reg_lshiftr()
 	}
 }
 
-#if !defined(MIPP_SSE1)
 TEST_CASE("Binary left shift (register) - mipp::Reg", "[mipp::lshiftr]")
 {
 #if !defined(MIPP_AVX) || (defined(MIPP_AVX) && MIPP_INSTR_VERSION >= 2)
@@ -92,4 +89,3 @@ TEST_CASE("Binary left shift (register) - mipp::Reg", "[mipp::lshiftr]")
 #endif
 #endif
 }
-#endif

--- a/tests/src/bitwise_operations/lshiftr.cpp
+++ b/tests/src/bitwise_operations/lshiftr.cpp
@@ -30,7 +30,7 @@ void test_reg_lshiftr()
 }
 
 #ifndef MIPP_NO
-#if !defined(MIPP_SSE)
+#if !defined(MIPP_SSE1)
 TEST_CASE("Binary left shift (register) - mipp::reg", "[mipp::lshiftr]")
 {
 #if !defined(MIPP_AVX) || (defined(MIPP_AVX) && MIPP_INSTR_VERSION >= 2)
@@ -74,7 +74,7 @@ void test_Reg_lshiftr()
 	}
 }
 
-#if !defined(MIPP_SSE)
+#if !defined(MIPP_SSE1)
 TEST_CASE("Binary left shift (register) - mipp::Reg", "[mipp::lshiftr]")
 {
 #if !defined(MIPP_AVX) || (defined(MIPP_AVX) && MIPP_INSTR_VERSION >= 2)

--- a/tests/src/bitwise_operations/rshiftr.cpp
+++ b/tests/src/bitwise_operations/rshiftr.cpp
@@ -30,7 +30,7 @@ void test_reg_rshiftr()
 }
 
 #ifndef MIPP_NO
-#if !defined(MIPP_SSE)
+#if !defined(MIPP_SSE1)
 TEST_CASE("Binary right shift (register) - mipp::reg", "[mipp::rshiftr]")
 {
 #if !defined(MIPP_AVX) || (defined(MIPP_AVX) && MIPP_INSTR_VERSION >= 2)
@@ -74,7 +74,7 @@ void test_Reg_rshiftr()
 	}
 }
 
-#if !defined(MIPP_SSE)
+#if !defined(MIPP_SSE1)
 TEST_CASE("Binary right shift (register) - mipp::Reg", "[mipp::rshiftr]")
 {
 #if !defined(MIPP_AVX) || (defined(MIPP_AVX) && MIPP_INSTR_VERSION >= 2)

--- a/tests/src/bitwise_operations/rshiftr.cpp
+++ b/tests/src/bitwise_operations/rshiftr.cpp
@@ -30,7 +30,6 @@ void test_reg_rshiftr()
 }
 
 #ifndef MIPP_NO
-#if !defined(MIPP_SSE1)
 TEST_CASE("Binary right shift (register) - mipp::reg", "[mipp::rshiftr]")
 {
 #if !defined(MIPP_AVX) || (defined(MIPP_AVX) && MIPP_INSTR_VERSION >= 2)
@@ -48,7 +47,6 @@ TEST_CASE("Binary right shift (register) - mipp::reg", "[mipp::rshiftr]")
 #endif
 #endif
 }
-#endif
 #endif
 
 template <typename T>
@@ -74,7 +72,6 @@ void test_Reg_rshiftr()
 	}
 }
 
-#if !defined(MIPP_SSE1)
 TEST_CASE("Binary right shift (register) - mipp::Reg", "[mipp::rshiftr]")
 {
 #if !defined(MIPP_AVX) || (defined(MIPP_AVX) && MIPP_INSTR_VERSION >= 2)
@@ -92,4 +89,3 @@ TEST_CASE("Binary right shift (register) - mipp::Reg", "[mipp::rshiftr]")
 #endif
 #endif
 }
-#endif


### PR DESCRIPTION
This adds lshiftr and lshiftr implementations for SSE2 and above.

There is no actual instruction corresponding to a vectorised shift with a vector or shift count in SSE (unlike what is in AVX2 and AVX512).
So this is simply a non vectorised execution.

I changed the test conditions to check the new functions, and they pass.