### PR TITLE
Fix `Regx2::store()` and `Regx2::storeu()`

### DIFF
--- a/include/mipp_object.hxx
+++ b/include/mipp_object.hxx
@@ -746,8 +746,8 @@ public:
 #else
 	inline void     load        (const T* data   )       { val[0] = data[0]; val[1] = data[1];                                                    }
 	inline void     loadu       (const T* data   )       { val[0] = data[0]; val[1] = data[1];                                                    }
-	inline void     store       (T* data         ) const { data[0] = val[0]; data[1] = val[1];                                                    }
-	inline void     storeu      (T* data         ) const { data[0] = val[0]; data[1] = val[1];                                                    }
+	inline void     store       (T* data         ) const { data[0] = val[0].r; data[1] = val[1].r;                                                }
+	inline void     storeu      (T* data         ) const { data[0] = val[0].r; data[1] = val[1].r;                                                }
 	inline Regx2<T> interleave  (                ) const { return *this;                                                                          }
 	inline Regx2<T> deinterleave(                ) const { return *this;                                                                          }
 	inline Regx2<T> conj        (                ) const { return Regx2<T>(val[0].r, -val[1].r);                                                  }


### PR DESCRIPTION
The implentations of `Regx2::store()` and `Regx2::storeu()` with `MIPP_NO_INTRINSICS` are incorrect because `Reg<T>` cannot be implicitly converted to `T`. The value in `Reg<T>` should be accessed explicitly.

In contrast, `Regx2::load()` and `Regx2::loadu()` use the exact reverse assignment approach but work correctly because `Reg<T>` includes a constructor `Reg(const T val)`, which allows implicit conversion from `T` to `Reg<T>`.