### PR TITLE
feat: add rsqrt with prec step on NEON float 32

### DIFF
--- a/include/mipp.h
+++ b/include/mipp.h
@@ -793,6 +793,7 @@ template <typename T> inline reg   neg          (const reg, const msk)          
 template <typename T> inline reg   abs          (const reg)                       { errorMessage<T>("abs");           exit(-1); }
 template <typename T> inline reg   sqrt         (const reg)                       { errorMessage<T>("sqrt");          exit(-1); }
 template <typename T> inline reg   rsqrt        (const reg)                       { errorMessage<T>("rsqrt");         exit(-1); }
+template <typename T> inline reg   rsqrt_prec   (const reg v)                     { return rsqrt<T>(v); }
 template <typename T> inline reg   log          (const reg)                       { errorMessage<T>("log");           exit(-1); }
 template <typename T> inline reg   exp          (const reg)                       { errorMessage<T>("exp");           exit(-1); }
 template <typename T> inline reg   sin          (const reg)                       { errorMessage<T>("sin");           exit(-1); }

--- a/include/mipp_impl_NEON.hxx
+++ b/include/mipp_impl_NEON.hxx
@@ -2815,6 +2815,13 @@
 		return vrsqrteq_f32(v1);
 	}
 
+	template <>
+	inline reg rsqrt_prec<float>(const reg v1) {
+		float32x4_t approx = vrsqrteq_f32(v1);
+		return vrsqrtsq_f32(v1 * approx, approx) * approx;
+	}
+
+
 	// ----------------------------------------------------------------------------------------------------------- sqrt
 #ifdef __aarch64__
 	template <>

--- a/include/mipp_object.hxx
+++ b/include/mipp_object.hxx
@@ -204,6 +204,7 @@ public:
 	inline Reg<T>      abs          ()                                     const { return mipp::abs          <T>(r);              }
 	inline Reg<T>      sqrt         ()                                     const { return mipp::sqrt         <T>(r);              }
 	inline Reg<T>      rsqrt        ()                                     const { return mipp::rsqrt        <T>(r);              }
+	inline Reg<T>      rsqrt_prec   ()                                     const { return mipp::rsqrt_prec   <T>(r);              }
 	inline Reg<T>      log          ()                                     const { return mipp::log          <T>(r);              }
 	inline Reg<T>      exp          ()                                     const { return mipp::exp          <T>(r);              }
 	inline Reg<T>      sin          ()                                     const { return mipp::sin          <T>(r);              }
@@ -305,6 +306,7 @@ public:
 	inline Reg<T>      abs          ()                                     const { return std::abs(r);                            }
 	inline Reg<T>      sqrt         ()                                     const { return (T)std::sqrt(r);                        }
 	inline Reg<T>      rsqrt        ()                                     const { return (T)(1 / std::sqrt(r));                  }
+	inline Reg<T>      rsqrt_prec   ()                                     const { return (T)(1 / std::sqrt(r));                  }
 	inline Reg<T>      log          ()                                     const { return (T)std::log(r);                         }
 	inline Reg<T>      exp          ()                                     const { return (T)std::exp(r);                         }
 	inline Reg<T>      sin          ()                                     const { return (T)std::sin(r);                         }
@@ -920,6 +922,7 @@ template <typename T>        inline Reg<T>      copysign     (const Reg<T> v1, c
 template <typename T>        inline Reg<T>      abs          (const Reg<T> v)                                        { return v.abs();                    }
 template <typename T>        inline Reg<T>      sqrt         (const Reg<T> v)                                        { return v.sqrt();                   }
 template <typename T>        inline Reg<T>      rsqrt        (const Reg<T> v)                                        { return v.rsqrt();                  }
+template <typename T>        inline Reg<T>      rsqrt_prec   (const Reg<T> v)                                        { return v.rsqrt_prec();             }
 template <typename T>        inline Reg<T>      log          (const Reg<T> v)                                        { return v.log();                    }
 template <typename T>        inline Reg<T>      exp          (const Reg<T> v)                                        { return v.exp();                    }
 template <typename T>        inline Reg<T>      sin          (const Reg<T> v)                                        { return v.sin();                    }


### PR DESCRIPTION
Add `rsqrt_prec` instruction which add precision for `rsqrt` on NEON target.
We add a precision step using `vrsqrtsq_f32` (https://developer.arm.com/architectures/instruction-sets/intrinsics/vrsqrtsq_f32).