### PR TITLE
Add int8/int16 reduction fallbacks for SSE2 and AVX

### DIFF
--- a/include/mipp_impl_AVX.hxx
+++ b/include/mipp_impl_AVX.hxx
@@ -5044,6 +5044,75 @@
 			return val;
 		}
 	};
+#else // AVX fallback (without AVX2): use _mm256_shuffle_ps + extract to 128-bit for SSSE3 byte shuffle
+	template <red_op<int16_t> OP>
+	struct _reduction<int16_t,OP>
+	{
+		static reg apply(const reg v1) {
+			__m128i mask_16 = _mm_set_epi8(13, 12, 15, 14, 9, 8, 11, 10, 5, 4, 7, 6, 1, 0, 3, 2);
+
+			auto val = v1;
+			val = OP(val, _mm256_permute2f128_ps(val, val, _MM_SHUFFLE(0,0,0,1)));
+			val = OP(val, _mm256_shuffle_ps     (val, val, _MM_SHUFFLE(1,0,3,2)));
+			val = OP(val, _mm256_shuffle_ps     (val, val, _MM_SHUFFLE(2,3,0,1)));
+			// swap 16-bit pairs: extract low half, SSSE3 shuffle, broadcast back
+			__m128i lo = _mm_castps_si128(_mm256_castps256_ps128(val));
+			__m128 sh  = _mm_castsi128_ps(_mm_shuffle_epi8(lo, mask_16));
+			val = OP(val, _mm256_insertf128_ps(_mm256_castps128_ps256(sh), sh, 1));
+			return val;
+		}
+	};
+
+	template <Red_op<int16_t> OP>
+	struct _Reduction<int16_t,OP>
+	{
+		static Reg<int16_t> apply(const Reg<int16_t> v1) {
+			__m128i mask_16 = _mm_set_epi8(13, 12, 15, 14, 9, 8, 11, 10, 5, 4, 7, 6, 1, 0, 3, 2);
+
+			auto val = v1;
+			val = OP(val, Reg<int16_t>(_mm256_permute2f128_ps(val.r, val.r, _MM_SHUFFLE(0,0,0,1))));
+			val = OP(val, Reg<int16_t>(_mm256_shuffle_ps     (val.r, val.r, _MM_SHUFFLE(1,0,3,2))));
+			val = OP(val, Reg<int16_t>(_mm256_shuffle_ps     (val.r, val.r, _MM_SHUFFLE(2,3,0,1))));
+			__m128i lo = _mm_castps_si128(_mm256_castps256_ps128(val.r));
+			__m128 sh  = _mm_castsi128_ps(_mm_shuffle_epi8(lo, mask_16));
+			val = OP(val, Reg<int16_t>(_mm256_insertf128_ps(_mm256_castps128_ps256(sh), sh, 1)));
+			return val;
+		}
+	};
+
+	template <red_op<uint16_t> OP>
+	struct _reduction<uint16_t,OP>
+	{
+		static reg apply(const reg v1) {
+			__m128i mask_16 = _mm_set_epi8(13, 12, 15, 14, 9, 8, 11, 10, 5, 4, 7, 6, 1, 0, 3, 2);
+
+			auto val = v1;
+			val = OP(val, _mm256_permute2f128_ps(val, val, _MM_SHUFFLE(0,0,0,1)));
+			val = OP(val, _mm256_shuffle_ps     (val, val, _MM_SHUFFLE(1,0,3,2)));
+			val = OP(val, _mm256_shuffle_ps     (val, val, _MM_SHUFFLE(2,3,0,1)));
+			__m128i lo = _mm_castps_si128(_mm256_castps256_ps128(val));
+			__m128 sh  = _mm_castsi128_ps(_mm_shuffle_epi8(lo, mask_16));
+			val = OP(val, _mm256_insertf128_ps(_mm256_castps128_ps256(sh), sh, 1));
+			return val;
+		}
+	};
+
+	template <Red_op<uint16_t> OP>
+	struct _Reduction<uint16_t,OP>
+	{
+		static Reg<uint16_t> apply(const Reg<uint16_t> v1) {
+			__m128i mask_16 = _mm_set_epi8(13, 12, 15, 14, 9, 8, 11, 10, 5, 4, 7, 6, 1, 0, 3, 2);
+
+			auto val = v1;
+			val = OP(val, Reg<uint16_t>(_mm256_permute2f128_ps(val.r, val.r, _MM_SHUFFLE(0,0,0,1))));
+			val = OP(val, Reg<uint16_t>(_mm256_shuffle_ps     (val.r, val.r, _MM_SHUFFLE(1,0,3,2))));
+			val = OP(val, Reg<uint16_t>(_mm256_shuffle_ps     (val.r, val.r, _MM_SHUFFLE(2,3,0,1))));
+			__m128i lo = _mm_castps_si128(_mm256_castps256_ps128(val.r));
+			__m128 sh  = _mm_castsi128_ps(_mm_shuffle_epi8(lo, mask_16));
+			val = OP(val, Reg<uint16_t>(_mm256_insertf128_ps(_mm256_castps128_ps256(sh), sh, 1)));
+			return val;
+		}
+	};
 #endif
 
 #ifdef __AVX2__
@@ -5143,6 +5212,92 @@
 			                                                                         mask_16))));
 			val = OP(val, Reg<uint8_t>(_mm256_castsi256_ps(_mm256_shuffle_epi8      (_mm256_castps_si256(val.r),
 			                                                                         mask_8))));
+			return val;
+		}
+	};
+#else // AVX fallback (without AVX2): use _mm256_shuffle_ps + extract to 128-bit for SSSE3 byte shuffle
+	template <red_op<int8_t> OP>
+	struct _reduction<int8_t,OP>
+	{
+		static reg apply(const reg v1) {
+			__m128i mask_16 = _mm_set_epi8(13, 12, 15, 14, 9, 8, 11, 10, 5, 4, 7, 6, 1, 0, 3, 2);
+			__m128i mask_8  = _mm_set_epi8(14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1);
+
+			auto val = v1;
+			val = OP(val, _mm256_permute2f128_ps(val, val, _MM_SHUFFLE(0,0,0,1)));
+			val = OP(val, _mm256_shuffle_ps     (val, val, _MM_SHUFFLE(1,0,3,2)));
+			val = OP(val, _mm256_shuffle_ps     (val, val, _MM_SHUFFLE(2,3,0,1)));
+			// swap 16-bit pairs: extract low half, SSSE3 shuffle, broadcast back
+			__m128i lo = _mm_castps_si128(_mm256_castps256_ps128(val));
+			__m128 sh  = _mm_castsi128_ps(_mm_shuffle_epi8(lo, mask_16));
+			val = OP(val, _mm256_insertf128_ps(_mm256_castps128_ps256(sh), sh, 1));
+			// swap adjacent bytes: extract low half, SSSE3 shuffle, broadcast back
+			lo = _mm_castps_si128(_mm256_castps256_ps128(val));
+			sh = _mm_castsi128_ps(_mm_shuffle_epi8(lo, mask_8));
+			val = OP(val, _mm256_insertf128_ps(_mm256_castps128_ps256(sh), sh, 1));
+			return val;
+		}
+	};
+
+	template <Red_op<int8_t> OP>
+	struct _Reduction<int8_t,OP>
+	{
+		static Reg<int8_t> apply(const Reg<int8_t> v1) {
+			__m128i mask_16 = _mm_set_epi8(13, 12, 15, 14, 9, 8, 11, 10, 5, 4, 7, 6, 1, 0, 3, 2);
+			__m128i mask_8  = _mm_set_epi8(14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1);
+
+			auto val = v1;
+			val = OP(val, Reg<int8_t>(_mm256_permute2f128_ps(val.r, val.r, _MM_SHUFFLE(0,0,0,1))));
+			val = OP(val, Reg<int8_t>(_mm256_shuffle_ps     (val.r, val.r, _MM_SHUFFLE(1,0,3,2))));
+			val = OP(val, Reg<int8_t>(_mm256_shuffle_ps     (val.r, val.r, _MM_SHUFFLE(2,3,0,1))));
+			__m128i lo = _mm_castps_si128(_mm256_castps256_ps128(val.r));
+			__m128 sh  = _mm_castsi128_ps(_mm_shuffle_epi8(lo, mask_16));
+			val = OP(val, Reg<int8_t>(_mm256_insertf128_ps(_mm256_castps128_ps256(sh), sh, 1)));
+			lo = _mm_castps_si128(_mm256_castps256_ps128(val.r));
+			sh = _mm_castsi128_ps(_mm_shuffle_epi8(lo, mask_8));
+			val = OP(val, Reg<int8_t>(_mm256_insertf128_ps(_mm256_castps128_ps256(sh), sh, 1)));
+			return val;
+		}
+	};
+
+	template <red_op<uint8_t> OP>
+	struct _reduction<uint8_t,OP>
+	{
+		static reg apply(const reg v1) {
+			__m128i mask_16 = _mm_set_epi8(13, 12, 15, 14, 9, 8, 11, 10, 5, 4, 7, 6, 1, 0, 3, 2);
+			__m128i mask_8  = _mm_set_epi8(14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1);
+
+			auto val = v1;
+			val = OP(val, _mm256_permute2f128_ps(val, val, _MM_SHUFFLE(0,0,0,1)));
+			val = OP(val, _mm256_shuffle_ps     (val, val, _MM_SHUFFLE(1,0,3,2)));
+			val = OP(val, _mm256_shuffle_ps     (val, val, _MM_SHUFFLE(2,3,0,1)));
+			__m128i lo = _mm_castps_si128(_mm256_castps256_ps128(val));
+			__m128 sh  = _mm_castsi128_ps(_mm_shuffle_epi8(lo, mask_16));
+			val = OP(val, _mm256_insertf128_ps(_mm256_castps128_ps256(sh), sh, 1));
+			lo = _mm_castps_si128(_mm256_castps256_ps128(val));
+			sh = _mm_castsi128_ps(_mm_shuffle_epi8(lo, mask_8));
+			val = OP(val, _mm256_insertf128_ps(_mm256_castps128_ps256(sh), sh, 1));
+			return val;
+		}
+	};
+
+	template <Red_op<uint8_t> OP>
+	struct _Reduction<uint8_t,OP>
+	{
+		static Reg<uint8_t> apply(const Reg<uint8_t> v1) {
+			__m128i mask_16 = _mm_set_epi8(13, 12, 15, 14, 9, 8, 11, 10, 5, 4, 7, 6, 1, 0, 3, 2);
+			__m128i mask_8  = _mm_set_epi8(14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1);
+
+			auto val = v1;
+			val = OP(val, Reg<uint8_t>(_mm256_permute2f128_ps(val.r, val.r, _MM_SHUFFLE(0,0,0,1))));
+			val = OP(val, Reg<uint8_t>(_mm256_shuffle_ps     (val.r, val.r, _MM_SHUFFLE(1,0,3,2))));
+			val = OP(val, Reg<uint8_t>(_mm256_shuffle_ps     (val.r, val.r, _MM_SHUFFLE(2,3,0,1))));
+			__m128i lo = _mm_castps_si128(_mm256_castps256_ps128(val.r));
+			__m128 sh  = _mm_castsi128_ps(_mm_shuffle_epi8(lo, mask_16));
+			val = OP(val, Reg<uint8_t>(_mm256_insertf128_ps(_mm256_castps128_ps256(sh), sh, 1)));
+			lo = _mm_castps_si128(_mm256_castps256_ps128(val.r));
+			sh = _mm_castsi128_ps(_mm_shuffle_epi8(lo, mask_8));
+			val = OP(val, Reg<uint8_t>(_mm256_insertf128_ps(_mm256_castps128_ps256(sh), sh, 1)));
 			return val;
 		}
 	};

--- a/include/mipp_impl_SSE.hxx
+++ b/include/mipp_impl_SSE.hxx
@@ -3881,6 +3881,62 @@
 			return val;
 		}
 	};
+#else // SSE2 fallback: use _mm_shufflelo/hi_epi16 instead of _mm_shuffle_epi8
+	template <red_op<int16_t> OP>
+	struct _reduction<int16_t,OP>
+	{
+		static reg apply(const reg v1) {
+			auto val = v1;
+			val = OP(val, _mm_castsi128_ps(_mm_shuffle_epi32(_mm_castps_si128(val), _MM_SHUFFLE(1, 0, 3, 2))));
+			val = OP(val, _mm_castsi128_ps(_mm_shuffle_epi32(_mm_castps_si128(val), _MM_SHUFFLE(2, 3, 0, 1))));
+			auto vi = _mm_castps_si128(val);
+			val = OP(val, _mm_castsi128_ps(_mm_shufflehi_epi16(_mm_shufflelo_epi16(vi, _MM_SHUFFLE(2, 3, 0, 1)),
+			                                                                            _MM_SHUFFLE(2, 3, 0, 1))));
+			return val;
+		}
+	};
+
+	template <Red_op<int16_t> OP>
+	struct _Reduction<int16_t,OP>
+	{
+		static Reg<int16_t> apply(const Reg<int16_t> v1) {
+			auto val = v1;
+			val = OP(val, Reg<int16_t>(_mm_castsi128_ps(_mm_shuffle_epi32(_mm_castps_si128(val.r), _MM_SHUFFLE(1, 0, 3, 2)))));
+			val = OP(val, Reg<int16_t>(_mm_castsi128_ps(_mm_shuffle_epi32(_mm_castps_si128(val.r), _MM_SHUFFLE(2, 3, 0, 1)))));
+			auto vi = _mm_castps_si128(val.r);
+			val = OP(val, Reg<int16_t>(_mm_castsi128_ps(_mm_shufflehi_epi16(_mm_shufflelo_epi16(vi, _MM_SHUFFLE(2, 3, 0, 1)),
+			                                                                                        _MM_SHUFFLE(2, 3, 0, 1)))));
+			return val;
+		}
+	};
+
+	template <red_op<uint16_t> OP>
+	struct _reduction<uint16_t,OP>
+	{
+		static reg apply(const reg v1) {
+			auto val = v1;
+			val = OP(val, _mm_castsi128_ps(_mm_shuffle_epi32(_mm_castps_si128(val), _MM_SHUFFLE(1, 0, 3, 2))));
+			val = OP(val, _mm_castsi128_ps(_mm_shuffle_epi32(_mm_castps_si128(val), _MM_SHUFFLE(2, 3, 0, 1))));
+			auto vi = _mm_castps_si128(val);
+			val = OP(val, _mm_castsi128_ps(_mm_shufflehi_epi16(_mm_shufflelo_epi16(vi, _MM_SHUFFLE(2, 3, 0, 1)),
+			                                                                            _MM_SHUFFLE(2, 3, 0, 1))));
+			return val;
+		}
+	};
+
+	template <Red_op<uint16_t> OP>
+	struct _Reduction<uint16_t,OP>
+	{
+		static Reg<uint16_t> apply(const Reg<uint16_t> v1) {
+			auto val = v1;
+			val = OP(val, Reg<uint16_t>(_mm_castsi128_ps(_mm_shuffle_epi32(_mm_castps_si128(val.r), _MM_SHUFFLE(1, 0, 3, 2)))));
+			val = OP(val, Reg<uint16_t>(_mm_castsi128_ps(_mm_shuffle_epi32(_mm_castps_si128(val.r), _MM_SHUFFLE(2, 3, 0, 1)))));
+			auto vi = _mm_castps_si128(val.r);
+			val = OP(val, Reg<uint16_t>(_mm_castsi128_ps(_mm_shufflehi_epi16(_mm_shufflelo_epi16(vi, _MM_SHUFFLE(2, 3, 0, 1)),
+			                                                                                         _MM_SHUFFLE(2, 3, 0, 1)))));
+			return val;
+		}
+	};
 #endif
 
 #ifdef __SSSE3__
@@ -3944,6 +4000,74 @@
 			val = OP(val, Reg<uint8_t>(_mm_castsi128_ps(_mm_shuffle_epi32(_mm_castps_si128(val.r), _MM_SHUFFLE(2, 3, 0, 1)))));
 			val = OP(val, Reg<uint8_t>(_mm_castsi128_ps(_mm_shuffle_epi8 (_mm_castps_si128(val.r), mask_16))));
 			val = OP(val, Reg<uint8_t>(_mm_castsi128_ps(_mm_shuffle_epi8 (_mm_castps_si128(val.r), mask_8))));
+			return val;
+		}
+	};
+#else // SSE2 fallback: use _mm_shufflelo/hi_epi16 + shifts instead of _mm_shuffle_epi8
+	template <red_op<int8_t> OP>
+	struct _reduction<int8_t,OP>
+	{
+		static reg apply(const reg v1) {
+			auto val = v1;
+			val = OP(val, _mm_castsi128_ps(_mm_shuffle_epi32(_mm_castps_si128(val), _MM_SHUFFLE(1, 0, 3, 2))));
+			val = OP(val, _mm_castsi128_ps(_mm_shuffle_epi32(_mm_castps_si128(val), _MM_SHUFFLE(2, 3, 0, 1))));
+			// swap 16-bit pairs within 32-bit words (SSE2: _mm_shufflelo/hi_epi16)
+			auto vi = _mm_castps_si128(val);
+			val = OP(val, _mm_castsi128_ps(_mm_shufflehi_epi16(_mm_shufflelo_epi16(vi, _MM_SHUFFLE(2, 3, 0, 1)),
+			                                                                            _MM_SHUFFLE(2, 3, 0, 1))));
+			// swap adjacent bytes within 16-bit words (SSE2: shift + or)
+			vi = _mm_castps_si128(val);
+			val = OP(val, _mm_castsi128_ps(_mm_or_si128(_mm_srli_epi16(vi, 8), _mm_slli_epi16(vi, 8))));
+			return val;
+		}
+	};
+
+	template <Red_op<int8_t> OP>
+	struct _Reduction<int8_t,OP>
+	{
+		static Reg<int8_t> apply(const Reg<int8_t> v1) {
+			auto val = v1;
+			val = OP(val, Reg<int8_t>(_mm_castsi128_ps(_mm_shuffle_epi32(_mm_castps_si128(val.r), _MM_SHUFFLE(1, 0, 3, 2)))));
+			val = OP(val, Reg<int8_t>(_mm_castsi128_ps(_mm_shuffle_epi32(_mm_castps_si128(val.r), _MM_SHUFFLE(2, 3, 0, 1)))));
+			// swap 16-bit pairs within 32-bit words (SSE2: _mm_shufflelo/hi_epi16)
+			auto vi = _mm_castps_si128(val.r);
+			val = OP(val, Reg<int8_t>(_mm_castsi128_ps(_mm_shufflehi_epi16(_mm_shufflelo_epi16(vi, _MM_SHUFFLE(2, 3, 0, 1)),
+			                                                                                        _MM_SHUFFLE(2, 3, 0, 1)))));
+			// swap adjacent bytes within 16-bit words (SSE2: shift + or)
+			vi = _mm_castps_si128(val.r);
+			val = OP(val, Reg<int8_t>(_mm_castsi128_ps(_mm_or_si128(_mm_srli_epi16(vi, 8), _mm_slli_epi16(vi, 8)))));
+			return val;
+		}
+	};
+
+	template <red_op<uint8_t> OP>
+	struct _reduction<uint8_t,OP>
+	{
+		static reg apply(const reg v1) {
+			auto val = v1;
+			val = OP(val, _mm_castsi128_ps(_mm_shuffle_epi32(_mm_castps_si128(val), _MM_SHUFFLE(1, 0, 3, 2))));
+			val = OP(val, _mm_castsi128_ps(_mm_shuffle_epi32(_mm_castps_si128(val), _MM_SHUFFLE(2, 3, 0, 1))));
+			auto vi = _mm_castps_si128(val);
+			val = OP(val, _mm_castsi128_ps(_mm_shufflehi_epi16(_mm_shufflelo_epi16(vi, _MM_SHUFFLE(2, 3, 0, 1)),
+			                                                                            _MM_SHUFFLE(2, 3, 0, 1))));
+			vi = _mm_castps_si128(val);
+			val = OP(val, _mm_castsi128_ps(_mm_or_si128(_mm_srli_epi16(vi, 8), _mm_slli_epi16(vi, 8))));
+			return val;
+		}
+	};
+
+	template <Red_op<uint8_t> OP>
+	struct _Reduction<uint8_t,OP>
+	{
+		static Reg<uint8_t> apply(const Reg<uint8_t> v1) {
+			auto val = v1;
+			val = OP(val, Reg<uint8_t>(_mm_castsi128_ps(_mm_shuffle_epi32(_mm_castps_si128(val.r), _MM_SHUFFLE(1, 0, 3, 2)))));
+			val = OP(val, Reg<uint8_t>(_mm_castsi128_ps(_mm_shuffle_epi32(_mm_castps_si128(val.r), _MM_SHUFFLE(2, 3, 0, 1)))));
+			auto vi = _mm_castps_si128(val.r);
+			val = OP(val, Reg<uint8_t>(_mm_castsi128_ps(_mm_shufflehi_epi16(_mm_shufflelo_epi16(vi, _MM_SHUFFLE(2, 3, 0, 1)),
+			                                                                                        _MM_SHUFFLE(2, 3, 0, 1)))));
+			vi = _mm_castps_si128(val.r);
+			val = OP(val, Reg<uint8_t>(_mm_castsi128_ps(_mm_or_si128(_mm_srli_epi16(vi, 8), _mm_slli_epi16(vi, 8)))));
 			return val;
 		}
 	};

--- a/tests/src/reductions/hadd.cpp
+++ b/tests/src/reductions/hadd.cpp
@@ -74,11 +74,9 @@ TEST_CASE("Horizontal addition - mipp::reg", "[mipp::hadd]")
 	SECTION("datatype = int32_t") { test_reg_hadd_int<int32_t>(); }
 #endif
 #if defined(MIPP_BW)
-#if !defined(MIPP_SSE) || (defined(MIPP_SSE) && MIPP_INSTR_VERSION >= 31)
 	SECTION("datatype = int16_t") { test_reg_hadd_int<int16_t>(); }
 #ifndef _MSC_VER
 	SECTION("datatype = int8_t") { test_reg_hadd_int<int8_t>(); }
-#endif
 #endif
 #endif
 #endif
@@ -152,11 +150,9 @@ TEST_CASE("Horizontal addition - mipp::Reg", "[mipp::hadd]")
 	SECTION("datatype = int32_t") { test_Reg_hadd_int<int32_t>(); }
 #endif
 #if defined(MIPP_BW)
-#if !defined(MIPP_SSE) || (defined(MIPP_SSE) && MIPP_INSTR_VERSION >= 31)
 	SECTION("datatype = int16_t") { test_Reg_hadd_int<int16_t>(); }
 #ifndef _MSC_VER
 	SECTION("datatype = int8_t") { test_Reg_hadd_int<int8_t>(); }
-#endif
 #endif
 #endif
 #endif


### PR DESCRIPTION
## Summary

The `_reduction` and `_Reduction` specializations for `int8_t`, `int16_t`, `uint8_t`, and `uint16_t` were guarded by `#ifdef __SSSE3__` (SSE backend) and `#ifdef __AVX2__` (AVX backend), with no `#else` fallback. This caused a runtime crash (`exit(-1)`) when `hadd()` was called on these types from code compiled for baseline SSE2 or vanilla AVX.

This was discovered via aff3ct/aff3ct#216, where `bgemmt<int8_t>()` calls `mipp::hadd<int8_t>()` during LDPC matrix operations.

### Changes

**SSE2 fallback** (`mipp_impl_SSE.hxx`):
- Replaces `_mm_shuffle_epi8` (SSSE3) with `_mm_shufflelo_epi16` / `_mm_shufflehi_epi16` (SSE2) for 16-bit pair swaps
- Uses `_mm_srli_epi16` / `_mm_slli_epi16` + OR (SSE2) for adjacent byte swaps

**AVX fallback without AVX2** (`mipp_impl_AVX.hxx`):
- Replaces `_mm256_permute4x64_epi64`, `_mm256_shuffle_epi32`, `_mm256_shuffle_epi8` (all AVX2) with `_mm256_shuffle_ps` (AVX) for 64/32-bit shuffles
- Extracts to 128-bit halves + SSSE3 `_mm_shuffle_epi8` for byte-level shuffles

**Tests** (`tests/src/reductions/hadd.cpp`):
- Removed `MIPP_INSTR_VERSION >= 31` guard so `int8_t`/`int16_t` hadd tests run on all SSE versions

### Test results

| ISA | Assertions | Result |
|-----|-----------|--------|
| SSE2 | 1200 | All passed |
| AVX (no AVX2) | 400 | All passed |
| AVX2 (native) | 1200 | All passed |

## Test plan

- [x] Built and ran `hadd` tests for SSE2-only (`-msse2 -mno-sse3 -mno-ssse3 ...`)
- [x] Built and ran `hadd` tests for AVX-only (`-mavx -mno-avx2`)
- [x] Built and ran `hadd` tests for native AVX2 (`-march=native`)
- [x] Verified int8_t/int16_t sections now execute on SSE2 (previously skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)